### PR TITLE
Updated Items.

### DIFF
--- a/docs/source/module/collections.rst
+++ b/docs/source/module/collections.rst
@@ -105,6 +105,10 @@ item
             repr(Item(True)) # >>> Item(bytes=b'1', str='1', int=1, bool=True, original_type=bool)
             repr(Item("hello")) # >>> Item(bytes=b'hello', str='hello', int=None, bool=True, original_type=str)
 
+    The following functions are included:
+
+    .. automethod:: replace
+
 ----
 
 *******

--- a/toolbox/collections/item.py
+++ b/toolbox/collections/item.py
@@ -78,6 +78,15 @@ class Item:
 
         return self._type(self._item)
 
+    def replace(self, old: ItemType, new: ItemType, count: int = -1) -> bytes:
+        """``bytes.replace()`` functionality on item.
+
+        See Python `docs <https://docs.python.org/3/library/stdtypes.html?highlight=replace#bytes.replace>`_ for more info.
+        """
+        old = self.byte_item(item=old)
+        new = self.byte_item(item=new)
+        return self.raw.replace(old, new, count)
+
     def __pos__(self):
         """Returns the string representation of the object.
 


### PR DESCRIPTION
Added `replace()` function that acts the same way as `bytes.replace()` on `Item`. 
Needed for `ItemDict` and `ObjectDict` to work nicely together.